### PR TITLE
fix(auth): add Android OAuth callback screens to prevent 404

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -89,6 +89,14 @@ export default function RootLayout() {
               options={{ animation: "slide_from_bottom" }}
             />
             <Stack.Screen
+              name="auth"
+              options={{ animation: "none" }}
+            />
+            <Stack.Screen
+              name="auth/callback"
+              options={{ animation: "none" }}
+            />
+            <Stack.Screen
               name="(modal)"
               options={{
                 presentation: "modal",

--- a/app/auth.tsx
+++ b/app/auth.tsx
@@ -1,0 +1,74 @@
+import { useEffect } from "react";
+import { View, ActivityIndicator } from "react-native";
+import { useRouter } from "expo-router";
+import * as Linking from "expo-linking";
+import * as WebBrowser from "expo-web-browser";
+import { supabase } from "@/lib/supabase";
+import { useUI } from "@/context/UIContext";
+
+// Signals to Chrome Custom Tabs that the auth session is complete so the tab closes.
+WebBrowser.maybeCompleteAuthSession();
+
+/**
+ * OAuth callback screen for Android.
+ *
+ * On Android, Chrome Custom Tabs fire dizzydish://auth as a system deep link
+ * which opens the app here. WebBrowser.openAuthSessionAsync resolves without
+ * a URL in this case, so we exchange the tokens from the deep link URL directly.
+ *
+ * On iOS, ASWebAuthenticationSession intercepts the redirect and resolves
+ * openAuthSessionAsync inline — this screen is never reached.
+ */
+export default function Auth() {
+  const router = useRouter();
+  const { showToast } = useUI();
+
+  useEffect(() => {
+    const exchange = async (url: string) => {
+      try {
+        // PKCE flow — one-time code in the query string (?code=…)
+        const parsed = new URL(url);
+        const code = parsed.searchParams.get("code");
+        if (code) {
+          const { error } = await supabase.auth.exchangeCodeForSession(code);
+          if (error) throw error;
+          router.replace("/");
+          return;
+        }
+
+        // Implicit flow — tokens in the URL fragment (#access_token=…)
+        const fragment = url.includes("#") ? url.split("#")[1] : "";
+        const params = new URLSearchParams(fragment);
+        const accessToken = params.get("access_token");
+        const refreshToken = params.get("refresh_token");
+
+        if (accessToken && refreshToken) {
+          const { error } = await supabase.auth.setSession({
+            access_token: accessToken,
+            refresh_token: refreshToken,
+          });
+          if (error) throw error;
+          router.replace("/");
+          return;
+        }
+
+        // No auth params — session was already established by signInWithGoogle().
+        router.replace("/");
+      } catch {
+        showToast("Sign-in failed. Please try again.", "error");
+        router.replace("/");
+      }
+    };
+
+    Linking.getInitialURL().then((url) => {
+      if (url) exchange(url);
+      else router.replace("/");
+    });
+  }, [router, showToast]);
+
+  return (
+    <View className="flex-1 items-center justify-center bg-bg">
+      <ActivityIndicator color="#C65D3D" />
+    </View>
+  );
+}

--- a/app/auth/callback.tsx
+++ b/app/auth/callback.tsx
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+import { View, ActivityIndicator } from "react-native";
+import { useRouter } from "expo-router";
+import * as Linking from "expo-linking";
+import * as WebBrowser from "expo-web-browser";
+import { supabase } from "@/lib/supabase";
+import { useUI } from "@/context/UIContext";
+
+// On Android, signals to Chrome Custom Tabs that the auth session is complete.
+// On iOS (ASWebAuthenticationSession) this is a no-op.
+WebBrowser.maybeCompleteAuthSession();
+
+/**
+ * OAuth callback screen — only reached on Android.
+ *
+ * On iOS, WebBrowser.openAuthSessionAsync intercepts the redirect via
+ * ASWebAuthenticationSession and resolves inline in signInWithGoogle() before
+ * Expo Router ever sees the URL. On Android, Chrome Custom Tabs fire the deep
+ * link to the OS, which opens this screen, so we exchange the tokens here.
+ *
+ * Handles both:
+ *  - PKCE flow:     dizzydish://auth/callback?code=…
+ *  - Implicit flow: dizzydish://auth/callback#access_token=…&refresh_token=…
+ *
+ * onAuthStateChange in AuthContext picks up the session automatically after
+ * exchangeCodeForSession / setSession resolves.
+ */
+export default function AuthCallback() {
+  const router = useRouter();
+  const { showToast } = useUI();
+
+  useEffect(() => {
+    const exchange = async (url: string) => {
+      try {
+        // PKCE flow — one-time code in the query string
+        const parsed = new URL(url);
+        const code = parsed.searchParams.get("code");
+        if (code) {
+          const { error } = await supabase.auth.exchangeCodeForSession(code);
+          if (error) throw error;
+          router.replace("/");
+          return;
+        }
+
+        // Implicit flow — tokens in the URL fragment
+        const fragment = url.includes("#") ? url.split("#")[1] : "";
+        const params = new URLSearchParams(fragment);
+        const accessToken = params.get("access_token");
+        const refreshToken = params.get("refresh_token");
+
+        if (accessToken && refreshToken) {
+          const { error } = await supabase.auth.setSession({
+            access_token: accessToken,
+            refresh_token: refreshToken,
+          });
+          if (error) throw error;
+          router.replace("/");
+          return;
+        }
+
+        // No recognisable auth params — bail to home silently
+        router.replace("/");
+      } catch {
+        showToast("Sign-in failed. Please try again.", "error");
+        router.replace("/");
+      }
+    };
+
+    Linking.getInitialURL().then((url) => {
+      if (url) exchange(url);
+      else router.replace("/");
+    });
+  }, [router, showToast]);
+
+  return (
+    <View className="flex-1 items-center justify-center bg-bg">
+      <ActivityIndicator color="#C65D3D" />
+    </View>
+  );
+}

--- a/lib/CLAUDE.md
+++ b/lib/CLAUDE.md
@@ -62,11 +62,16 @@ Google sign-in uses `supabase.auth.signInWithOAuth` + `expo-web-browser`:
 
 **Supabase config required:**
 - Google provider enabled with Web Client ID + Secret
-- `dizzydish://auth/callback` in Redirect URLs (and `exp://` variant for dev)
+- `dizzydish://auth` **and** `dizzydish://auth/callback` in Redirect URLs (and `exp://` variant for dev)
+  - Android dev builds have been observed redirecting to `dizzydish://auth` rather than `dizzydish://auth/callback` — both must be allowed
 
 **Google Cloud Console config required:**
 - Web OAuth 2.0 Client ID with `https://<project>.supabase.co/auth/v1/callback` as authorized redirect URI
 - OAuth consent screen configured with authorized domains, test users (if in Testing mode)
+
+**Android callback screens:**
+- `app/auth.tsx` — handles `dizzydish://auth` deep links (observed on Android dev builds). Calls `WebBrowser.maybeCompleteAuthSession()` to close Chrome Custom Tabs, then exchanges tokens via PKCE (`exchangeCodeForSession`) or implicit flow (`setSession`). Falls through to `/` if the session was already established by `signInWithGoogle()`.
+- `app/auth/callback.tsx` — handles `dizzydish://auth/callback` deep links. Same token exchange logic. On iOS, `ASWebAuthenticationSession` intercepts the redirect before it fires as a deep link, so neither screen is reached on iOS.
 
 **Known limitation:** OAuth does not work in Expo Go. Requires a development build (`npx expo run:ios` / `run:android`).
 


### PR DESCRIPTION
## Summary

- On Android dev builds, Chrome Custom Tabs fire `dizzydish://auth` as a system deep link instead of returning the URL to `openAuthSessionAsync`. With no matching route, users hit Expo Router's built-in 404 screen with "go / sitemap" links.
- Add `app/auth.tsx` to handle `dizzydish://auth` — calls `maybeCompleteAuthSession()`, exchanges tokens (PKCE or implicit), and redirects to `/`.
- Add `app/auth/callback.tsx` with the same logic for `dizzydish://auth/callback` in case Supabase redirects to the longer path.
- Register both screens in `_layout.tsx` with `animation: "none"` so the transient spinner never visibly slides in.
- Update `lib/CLAUDE.md` to document the Android callback behaviour and note that both redirect URLs must be in Supabase's allowed list.

## Test plan

- [x] Build dev client with `npx expo run:android`
- [x] Tap Google sign-in — confirm Chrome Custom Tabs opens
- [x] Complete Google auth — confirm app returns directly to home screen with no 404 page
- [x] Verify session is established (user is signed in on home screen)
- [ ] Repeat on iOS (`npx expo run:ios`) — confirm existing flow still works

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)