### PR TITLE
chore(mcp): add Figma MCP server configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,7 @@
       "Bash(npm run test:ci:*)",
       "Bash(ls:*)",
       "mcp__figma__create_design_system_rules",
+      "mcp__figma__generate_figma_design",
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,6 +11,7 @@
       "Bash(npm run test:ci:*)",
       "Bash(ls:*)",
       "mcp__figma__create_design_system_rules",
+      "mcp__figma__generate_figma_design",
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp",
+      "headers": {
+        "X-Figma-Token": "${FIGMA_API_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Registers the Figma remote MCP server (mcp.figma.com) via .mcp.json
using an env-var token (FIGMA_API_TOKEN) so the token is never committed.

Adds mcp__figma__generate_figma_design permission to both settings files
alongside the existing mcp__figma__create_design_system_rules entry.

https://claude.ai/code/session_01DE78n9zsnSroZBL5GkhBT4

Before using it, you need to do one thing:
Go to figma.com/settings/developers → "Create new token" → copy it
Set it in your shell (add to your ~/.zshrc or ~/.bashrc to make it permanent):
export FIGMA_API_TOKEN=your_token_here
Restart Claude Code (exit + claude again)
To verify it's working:
/mcp
You should see figma listed as a connected server.
Then to start creating components in Figma:
Run npx expo start --web to get a browser-renderable version of your screens
Ask me to capture any screen: "Push the recipe result screen to a new Figma file called DizzyDish Screens"
I'll call mcp__figma__generate_figma_design, give you a JS snippet to paste in DevTools, and return the Figma URL when done