### PR TITLE
chore(mcp): add Figma MCP server configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,7 @@
       "Bash(npm run test:ci:*)",
       "Bash(ls:*)",
       "mcp__figma__create_design_system_rules",
+      "mcp__figma__generate_figma_design",
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,6 +11,7 @@
       "Bash(npm run test:ci:*)",
       "Bash(ls:*)",
       "mcp__figma__create_design_system_rules",
+      "mcp__figma__generate_figma_design",
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git push:*)",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp",
+      "headers": {
+        "X-Figma-Token": "${FIGMA_API_TOKEN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Registers the Figma remote MCP server (mcp.figma.com) via .mcp.json using an env-var token (FIGMA_API_TOKEN) so the token is never committed. Adds mcp__figma__generate_figma_design permission to both settings files alongside the existing mcp__figma__create_design_system_rules entry.

https://claude.ai/code/session_01DE78n9zsnSroZBL5GkhBT4

## Summary

<!-- What does this PR do? Why? -->

## Type of change

- [ ] `feat` — New feature
- [ ] `fix` — Bug fix
- [ ] `refactor` — Code change with no behavior change
- [ ] `chore` — Build, deps, config
- [ ] `docs` — Documentation only
- [ ] `test` — Tests only
- [ ] `style` — Formatting only
- [ ] `hotfix` — Urgent production fix

## PR checklist

- [ ] `npx tsc --noEmit` passes (no TypeScript errors)
- [ ] All existing tests pass (`npm run test:ci`)
- [ ] New features have tests
- [ ] Server data uses React Query — not Context
- [ ] Components have accessibility props (`accessibilityRole`, `accessibilityLabel`)
- [ ] No `StyleSheet.create()` unless NativeWind can't express it
- [ ] Animations use Reanimated (not the legacy Animated API)
- [ ] Haptic feedback added for interactive elements
- [ ] Loading, error, and empty states handled for all new queries

## Testing notes

<!-- How did you test this? Device/simulator, OS version, scenarios covered. -->

## Screenshots / recordings

<!-- Optional but encouraged for UI changes -->
