### PR TITLE
feat(ui): inline spin wheel and result card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 Dizzy Dish is a mobile recipe decision app designed for the overwhelmed parent at 6:30pm who just needs an answer. The core experience is a single "decide for me" spin button that selects a recipe (or a full weekly meal plan) based on the user's dietary preferences, time constraints, and calorie goals.
 
 **Core user flows:**
-1. **Single Spin** — Tap spin → animated sequence → recipe result with details, tags, ingredient ordering
-2. **Weekly Plan** — Toggle weekly mode → spin → 7-day plan with shared ingredient optimization → Instacart
+1. **Single Spin** — Tap spin → inline spinning wheel → result card on home screen → tap "View" for full details
+2. **Weekly Plan** — Toggle weekly mode → spin → inline wheel → 7-day plan card → tap "View" for full plan + Instacart
 3. **Save/Unsave Recipes** — Heart toggle on any result
 4. **Preferences** — Dietary filters (19 options), time (Any/Under 30/Under 60), calories (Any/Light/Moderate/Hearty); Pro users get persistent preferences
 5. **Account** — Identifier-first email auth via Supabase, Google OAuth, post-auth redirect

--- a/__tests__/CLAUDE.md
+++ b/__tests__/CLAUDE.md
@@ -42,7 +42,7 @@ npm test -- --testPathPattern=MyThing   # Run a single file
 - Use `mock` prefix for mutable variables referenced inside `jest.mock()` factories
 - `react-test-renderer` must match `react` version (both 19.1.0 if using React 19)
 
-## Existing test coverage (207 tests across 16 suites)
+## Existing test coverage (224 tests across 18 suites)
 | File | What it tests | Tests |
 |---|---|---|
 | `AuthContextReducer.test.ts` | `authReducer`, `mapSupabaseUser` pure functions | 6 |
@@ -61,6 +61,8 @@ npm test -- --testPathPattern=MyThing   # Run a single file
 | `Toggle.test.tsx` | Render, toggle behavior, haptics, a11y, color variants | 9 |
 | `SpinButton.test.tsx` | Render, label/hints, press/disabled, a11y, dimensions | 10 |
 | `HomeScreen.test.tsx` | Heading, nav tabs, weekly mode, context line filters, filter indicator | 13 |
+| `SpinningOverlay.test.tsx` | InlineSpinWheel: renders, haptic at 2000ms, onComplete at 2400ms | 3 |
+| `SpinResultCard.test.tsx` | Recipe/plan variants, meta pills, HeartButton, button callbacks | 12 |
 
 ## Adding a new test
 

--- a/__tests__/HomeScreen.test.tsx
+++ b/__tests__/HomeScreen.test.tsx
@@ -72,6 +72,12 @@ jest.mock("@/hooks/useGuestSpinLimit", () => ({
   }),
 }));
 
+jest.mock("@/hooks/useSavedRecipes", () => ({
+  useSavedRecipes: () => ({ data: [] }),
+  useSaveRecipe: () => ({ mutate: jest.fn() }),
+  useUnsaveRecipe: () => ({ mutate: jest.fn() }),
+}));
+
 jest.mock("expo-image", () => {
   const React = require("react");
   const { View } = require("react-native");

--- a/__tests__/SpinResultCard.test.tsx
+++ b/__tests__/SpinResultCard.test.tsx
@@ -1,0 +1,213 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+import type { Recipe, WeeklyPlan } from "@/types";
+
+// @/lib/haptics is globally mocked in jest.setup.js
+
+import { SpinResultCard } from "@/components/SpinResultCard";
+
+const mockRecipe: Recipe = {
+  id: "test-1",
+  name: "Spicy Lentil Soup",
+  time: "35 min",
+  calories: "420 cal",
+  servings: "4 servings",
+  description: "A hearty soup",
+  tags: ["Vegan", "Gluten Free"],
+  emoji: "\uD83C\uDF5C",
+};
+
+const mockPlan: WeeklyPlan = {
+  id: "plan-1",
+  days: [
+    { day: "Monday", recipe: { ...mockRecipe, id: "r1", name: "Pasta Primavera", emoji: "\uD83C\uDF5D" } },
+    { day: "Tuesday", recipe: { ...mockRecipe, id: "r2", name: "Grilled Chicken", emoji: "\uD83C\uDF57" } },
+    { day: "Wednesday", recipe: { ...mockRecipe, id: "r3", name: "Fish Tacos", emoji: "\uD83C\uDF2E" } },
+    { day: "Thursday", recipe: { ...mockRecipe, id: "r4", name: "Veggie Stir Fry", emoji: "\uD83E\uDD5F" } },
+    { day: "Friday", recipe: { ...mockRecipe, id: "r5", name: "Pizza Night", emoji: "\uD83C\uDF55" } },
+    { day: "Saturday", recipe: { ...mockRecipe, id: "r6", name: "Burger Bash", emoji: "\uD83C\uDF54" } },
+    { day: "Sunday", recipe: { ...mockRecipe, id: "r7", name: "Roast Dinner", emoji: "\uD83C\uDF56" } },
+  ],
+  sharedIngredients: [],
+  totalItems: 35,
+  reducedItems: 28,
+};
+
+describe("SpinResultCard", () => {
+  describe("recipe variant", () => {
+    it("renders recipe name and emoji", () => {
+      const { getByText } = render(
+        <SpinResultCard
+          result={{ type: "recipe", data: mockRecipe }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(getByText("Spicy Lentil Soup")).toBeTruthy();
+      expect(getByText("\uD83C\uDF5C")).toBeTruthy();
+    });
+
+    it("renders meta pills for time, calories, servings", () => {
+      const { getByText } = render(
+        <SpinResultCard
+          result={{ type: "recipe", data: mockRecipe }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(getByText("35 min")).toBeTruthy();
+      expect(getByText("420 cal")).toBeTruthy();
+      expect(getByText("4 servings")).toBeTruthy();
+    });
+
+    it("renders HeartButton when onToggleSave is provided", () => {
+      const { getByLabelText } = render(
+        <SpinResultCard
+          result={{ type: "recipe", data: mockRecipe }}
+          saved={false}
+          onToggleSave={jest.fn()}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(getByLabelText("Save recipe")).toBeTruthy();
+    });
+
+    it("does not render HeartButton when onToggleSave is not provided", () => {
+      const { queryByLabelText } = render(
+        <SpinResultCard
+          result={{ type: "recipe", data: mockRecipe }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(queryByLabelText("Save recipe")).toBeNull();
+      expect(queryByLabelText("Unsave recipe")).toBeNull();
+    });
+
+    it("renders View full recipe button", () => {
+      const { getByLabelText } = render(
+        <SpinResultCard
+          result={{ type: "recipe", data: mockRecipe }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(getByLabelText("View full recipe details")).toBeTruthy();
+    });
+
+    it("fires onViewFullRecipe when View button is pressed", () => {
+      const onView = jest.fn();
+      const { getByLabelText } = render(
+        <SpinResultCard
+          result={{ type: "recipe", data: mockRecipe }}
+          onViewFullRecipe={onView}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      fireEvent.press(getByLabelText("View full recipe details"));
+      expect(onView).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires onSpinAgain when Spin again button is pressed", () => {
+      const onSpin = jest.fn();
+      const { getByLabelText } = render(
+        <SpinResultCard
+          result={{ type: "recipe", data: mockRecipe }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={onSpin}
+        />
+      );
+      fireEvent.press(getByLabelText("Spin for another recipe"));
+      expect(onSpin).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not show calories pill when calories is dash", () => {
+      const recipe = { ...mockRecipe, calories: "—" };
+      const { queryByText } = render(
+        <SpinResultCard
+          result={{ type: "recipe", data: recipe }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(queryByText("—")).toBeNull();
+    });
+  });
+
+  describe("weekly plan variant", () => {
+    it("renders plan heading", () => {
+      const { getByText } = render(
+        <SpinResultCard
+          result={{ type: "plan", data: mockPlan }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(getByText("Your 7-day plan is ready")).toBeTruthy();
+    });
+
+    it("shows first 3 day previews", () => {
+      const { getByText } = render(
+        <SpinResultCard
+          result={{ type: "plan", data: mockPlan }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(getByText("Mon")).toBeTruthy();
+      expect(getByText("Pasta Primavera")).toBeTruthy();
+      expect(getByText("Tue")).toBeTruthy();
+      expect(getByText("Grilled Chicken")).toBeTruthy();
+      expect(getByText("Wed")).toBeTruthy();
+      expect(getByText("Fish Tacos")).toBeTruthy();
+    });
+
+    it("shows +N more for remaining days", () => {
+      const { getByText } = render(
+        <SpinResultCard
+          result={{ type: "plan", data: mockPlan }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(getByText("+4 more")).toBeTruthy();
+    });
+
+    it("does not render HeartButton for plan variant", () => {
+      const { queryByLabelText } = render(
+        <SpinResultCard
+          result={{ type: "plan", data: mockPlan }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(queryByLabelText("Save recipe")).toBeNull();
+      expect(queryByLabelText("Unsave recipe")).toBeNull();
+    });
+
+    it("renders View full plan button", () => {
+      const { getByLabelText } = render(
+        <SpinResultCard
+          result={{ type: "plan", data: mockPlan }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={jest.fn()}
+        />
+      );
+      expect(getByLabelText("View full weekly plan")).toBeTruthy();
+    });
+
+    it("fires onSpinAgain when Spin again button is pressed", () => {
+      const onSpin = jest.fn();
+      const { getByLabelText } = render(
+        <SpinResultCard
+          result={{ type: "plan", data: mockPlan }}
+          onViewFullRecipe={jest.fn()}
+          onSpinAgain={onSpin}
+        />
+      );
+      fireEvent.press(getByLabelText("Spin for another plan"));
+      expect(onSpin).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/__tests__/SpinningOverlay.test.tsx
+++ b/__tests__/SpinningOverlay.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import { haptic } from "@/lib/haptics";
+import { InlineSpinWheel } from "@/components/SpinningOverlay";
+
+// @/lib/haptics is globally mocked in jest.setup.js
+
+describe("InlineSpinWheel", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (haptic.success as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("renders wheel and status text", () => {
+    const { getByText, getByLabelText } = render(
+      <InlineSpinWheel onComplete={jest.fn()} />
+    );
+    expect(getByLabelText("Spinning for a recipe")).toBeTruthy();
+    expect(getByText("finding your meal...")).toBeTruthy();
+  });
+
+  it("calls haptic.success at 2000ms", () => {
+    render(<InlineSpinWheel onComplete={jest.fn()} />);
+
+    jest.advanceTimersByTime(1999);
+    expect(haptic.success).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(haptic.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onComplete at 2400ms (after bounce exit)", () => {
+    const onComplete = jest.fn();
+    render(<InlineSpinWheel onComplete={onComplete} />);
+
+    jest.advanceTimersByTime(2399);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -20,8 +20,14 @@ Stack-first model using **Expo Router** with file-based routing:
 ### Home Screen Navigation
 The home screen uses a **3-tab pill nav** at the bottom (me / spin / saved) instead of a tab navigator. The pill bar is a static View — "spin" is always active on the home screen. "me" opens the account modal, "saved" pushes to the saved recipes screen. The settings/preferences screen is accessed via a **hamburger menu** icon in the top-right, which shows a warm dot indicator when active filters are set.
 
+### Home Screen Center Area — 3 States
+The center area cycles through three inline states (no navigation, no overlay):
+1. **Idle** — `SpinButton` with context line above and guest upsell below
+2. **Spinning** — `InlineSpinWheel` replaces the button in-place (context line stays visible)
+3. **Result** — `SpinResultCard` with recipe/plan summary, "View full recipe" navigates to `/result` or `/weekly-result`, "Spin again" resets to idle
+
 ### Context Line
-A context line appears above the spin button showing the user's active filter summary (e.g. "< 30 min · Light · Vegan"). It only appears when filters differ from the defaults (time: "Any", calories: "Any", no dietary filters).
+A context line appears above the spin button/wheel showing the user's active filter summary (e.g. "< 30 min · Light · Vegan"). It only appears when filters differ from the defaults (time: "Any", calories: "Any", no dietary filters). It persists during spinning and hides when the result card appears.
 
 ### Adding a new route
 1. Create `app/my-route.tsx`

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import { Image } from "expo-image";
@@ -6,6 +6,8 @@ import Animated, { FadeInDown, FadeOut } from "react-native-reanimated";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { SpinButton } from "@/components/SpinButton";
+import { SpinResultCard } from "@/components/SpinResultCard";
+import { InlineSpinWheel } from "@/components/SpinningOverlay";
 import { Toggle } from "@/components/Toggle";
 import { useAuth } from "@/context/AuthContext";
 import { usePreferences } from "@/context/PreferencesContext";
@@ -15,20 +17,25 @@ import { useAuthRedirect } from "@/context/AuthRedirectContext";
 import { useSpinRecipe, useSpinWeeklyPlan } from "@/hooks/useSpinRecipe";
 import { useRecipePool } from "@/hooks/useRecipePool";
 import { useGuestSpinLimit } from "@/hooks/useGuestSpinLimit";
-import { SpinningOverlay } from "@/components/SpinningOverlay";
+import { useSavedRecipes, useSaveRecipe, useUnsaveRecipe } from "@/hooks/useSavedRecipes";
 import { Colors } from "@/constants/colors";
 import { haptic } from "@/lib/haptics";
+import type { Recipe, WeeklyPlan } from "@/types";
 
 const logo = require("@/assets/images/logo.png");
+
+type SpinResult =
+  | { type: "recipe"; data: Recipe }
+  | { type: "plan"; data: WeeklyPlan }
+  | null;
 
 /**
  * Home screen — the main entry point.
  *
- * "Designed for the parent at 6:30pm. One button. One answer. No noise."
- *
- * Server state: useRecipePool (Spoonacular), useSpinRecipe/useSpinWeeklyPlan mutations
- * Client state: PreferencesContext (weeklyMode, dietary, time, calories),
- *               UIContext (isSpinning), useGuestSpinLimit
+ * Center area has three states:
+ *  1. SpinButton (idle)
+ *  2. InlineSpinWheel (spinning — replaces button in-place)
+ *  3. SpinResultCard (result — animates up after spin completes)
  */
 export default function HomeScreen() {
   const router = useRouter();
@@ -43,15 +50,20 @@ export default function HomeScreen() {
   const { isLimitReached, spinsRemaining, incrementSpinCount } =
     useGuestSpinLimit();
 
+  // Saved recipes for heart toggle on result card
+  const { data: savedRecipes } = useSavedRecipes();
+  const saveRecipe = useSaveRecipe();
+  const unsaveRecipe = useUnsaveRecipe();
+
+  // Center area state: null = show button, "spinning" = show wheel, SpinResult = show card
+  const [spinResult, setSpinResult] = useState<SpinResult>(null);
+  const [isSpinAnimating, setIsSpinAnimating] = useState(false);
+
   if (__DEV__) {
     console.log('------------>', { isLimitReached, spinsRemaining, incrementSpinCount })
     if (pool.isError) console.log('[index.tsx] pool ERROR:', pool.error?.message);
     if (pool.isSuccess) console.log('[index.tsx] pool loaded —', pool.data?.length, 'recipes');
   }
-
-  // Store the last spun ID so handleSpinComplete can pass it as a nav param
-  const lastRecipeIdRef = useRef<string | null>(null);
-  const lastPlanIdRef = useRef<string | null>(null);
 
   const request = {
     dietary: Array.from(prefs.dietary),
@@ -67,17 +79,21 @@ export default function HomeScreen() {
       console.log('[index.tsx] request:', JSON.stringify(request));
     }
 
+    // Clear previous result and start the wheel animation
+    setSpinResult(null);
+    setIsSpinAnimating(true);
     setSpinning(true);
 
     if (prefs.weeklyMode) {
       spinWeeklyPlan.mutate(request, {
         onSuccess: (plan) => {
           if (__DEV__) console.log('[index.tsx] weekly plan drawn, id:', plan.id, '| days:', plan.days.length);
-          lastPlanIdRef.current = plan.id;
+          setSpinResult({ type: "plan", data: plan });
         },
         onError: (err) => {
           if (__DEV__) console.log('[index.tsx] weekly spin ERROR:', err.message);
           setSpinning(false);
+          setIsSpinAnimating(false);
           showToast(err.message, "error");
         },
       });
@@ -85,7 +101,7 @@ export default function HomeScreen() {
       spinRecipe.mutate(request, {
         onSuccess: (recipe) => {
           if (__DEV__) console.log('[index.tsx] recipe drawn:', recipe.name, '| id:', recipe.id);
-          lastRecipeIdRef.current = recipe.id;
+          setSpinResult({ type: "recipe", data: recipe });
           if (!auth.isAuthenticated) {
             incrementSpinCount();
           }
@@ -93,29 +109,58 @@ export default function HomeScreen() {
         onError: (err) => {
           if (__DEV__) console.log('[index.tsx] spin ERROR:', err.message);
           setSpinning(false);
+          setIsSpinAnimating(false);
           showToast(err.message, "error");
         },
       });
     }
   }, [prefs, request, pool.isLoading, pool.isError, pool.data, spinRecipe, spinWeeklyPlan, setSpinning, auth.isAuthenticated, incrementSpinCount]);
 
-  // Called when the spinning animation completes — navigate to the result screen
+  // Wheel animation finished — stop spinning, show the result card
   const handleSpinComplete = useCallback(() => {
     setSpinning(false);
-    if (prefs.weeklyMode) {
-      if (__DEV__) console.log('[index.tsx] handleSpinComplete — navigating to /weekly-result with planId:', lastPlanIdRef.current);
-      router.push({
-        pathname: "/weekly-result",
-        params: { planId: lastPlanIdRef.current ?? "" },
-      });
-    } else {
-      if (__DEV__) console.log('[index.tsx] handleSpinComplete — navigating to /result with recipeId:', lastRecipeIdRef.current);
+    setIsSpinAnimating(false);
+  }, [setSpinning]);
+
+  // Navigate to full result screen
+  const handleViewFullRecipe = useCallback(() => {
+    if (!spinResult) return;
+    if (spinResult.type === "recipe") {
       router.push({
         pathname: "/result",
-        params: { recipeId: lastRecipeIdRef.current ?? "" },
+        params: { recipeId: spinResult.data.id },
+      });
+    } else {
+      router.push({
+        pathname: "/weekly-result",
+        params: { planId: spinResult.data.id },
       });
     }
-  }, [prefs.weeklyMode, router, setSpinning]);
+  }, [spinResult, router]);
+
+  // Reset to spin button
+  const handleSpinAgain = useCallback(() => {
+    setSpinResult(null);
+  }, []);
+
+  // Heart toggle for recipe result
+  const isRecipeSaved =
+    spinResult?.type === "recipe" &&
+    (savedRecipes ?? []).some((r) => r.id === spinResult.data.id);
+
+  const handleToggleSave = useCallback(() => {
+    if (spinResult?.type !== "recipe") return;
+    if (!auth.isAuthenticated) {
+      setSnapshot("/");
+      router.push("/(modal)/account");
+      return;
+    }
+    if (isRecipeSaved) {
+      unsaveRecipe.mutate(spinResult.data.id);
+    } else {
+      saveRecipe.mutate({ recipeId: spinResult.data.id, recipe: spinResult.data });
+    }
+  }, [spinResult, isRecipeSaved, auth.isAuthenticated, savedRecipes, saveRecipe, unsaveRecipe, setSnapshot, router]);
 
   // Active filters drive the hamburger indicator + context line
   const hasActiveFilters =
@@ -127,12 +172,11 @@ export default function HomeScreen() {
   if (prefs.calories !== "Any") contextParts.push(prefs.calories);
   prefs.dietary.forEach((f) => contextParts.push(f));
 
-  // Show spinning overlay
-  if (ui.isSpinning) {
-    return <SpinningOverlay onComplete={handleSpinComplete} />;
-  }
-
   const spinDisabled = pool.isLoading || isLimitReached;
+
+  // Determine which center content to show
+  const showResult = spinResult && !isSpinAnimating;
+  const showWheel = isSpinAnimating;
 
   return (
     <SafeAreaView className="flex-1 bg-bg" edges={["top"]}>
@@ -140,7 +184,6 @@ export default function HomeScreen() {
 
         {/* ── Top bar ──────────────────────────────────────────────────── */}
         <View className="flex-row justify-between items-center py-1">
-          {/* Logo — contentPosition="left" anchors content to avoid inner whitespace offset */}
           <Image
             source={logo}
             style={{ width: 120, height: 40 }}
@@ -149,7 +192,6 @@ export default function HomeScreen() {
             accessibilityLabel="Dizzy Dish logo"
           />
 
-          {/* Hamburger menu with active filter indicator */}
           <Pressable
             onPress={() => { haptic.light(); router.push("/(modal)/settings"); }}
             accessibilityRole="button"
@@ -217,10 +259,10 @@ export default function HomeScreen() {
           </Text>
         </Animated.View>
 
-        {/* ── Spin button — THE main event ─────────────────────────────── */}
+        {/* ── Center area: Button → Wheel → Result Card ──────────────── */}
         <View className="flex-1 items-center justify-center">
-          {/* Context line — pre-spin confirmation, just above the button */}
-          {contextParts.length > 0 && (
+          {/* Context line — stays visible during idle and spinning */}
+          {!showResult && contextParts.length > 0 && (
             <Animated.View
               entering={FadeInDown.duration(300).springify()}
               exiting={FadeOut.duration(200)}
@@ -232,64 +274,81 @@ export default function HomeScreen() {
             </Animated.View>
           )}
 
-          <Animated.View
-            entering={FadeInDown.delay(200).duration(600).springify()}
-          >
-            <SpinButton
-              onPress={handleSpin}
-              weeklyMode={prefs.weeklyMode}
-              disabled={spinDisabled}
+          {showResult ? (
+            /* Result card — pops up after spin */
+            <SpinResultCard
+              result={spinResult}
+              saved={isRecipeSaved}
+              onToggleSave={handleToggleSave}
+              onViewFullRecipe={handleViewFullRecipe}
+              onSpinAgain={handleSpinAgain}
             />
-          </Animated.View>
-
-          {/* Guest limit upsell banner */}
-          {isLimitReached && !auth.isAuthenticated && (
-            <Animated.View
-              entering={FadeInDown.delay(100).duration(400).springify()}
-              className="mt-6 items-center"
-            >
-              <Text className="font-body text-sm text-txt-soft text-center mb-3">
-                You've used your 3 free spins for today.
-              </Text>
-              <Pressable
-                onPress={() => {
-                  setSnapshot("/");
-                  router.push("/(modal)/account");
-                }}
-                className="px-6 py-2.5 rounded-btn bg-warm"
-                accessibilityRole="button"
-                accessibilityLabel="Sign up for unlimited spins"
+          ) : showWheel ? (
+            /* Inline spinning wheel — same position/size as the button */
+            <InlineSpinWheel onComplete={handleSpinComplete} />
+          ) : (
+            /* Idle — spin button */
+            <>
+              <Animated.View
+                entering={FadeInDown.delay(200).duration(600).springify()}
               >
-                <Text className="font-body-medium text-sm text-white">
-                  Sign up for unlimited spins
-                </Text>
-              </Pressable>
-            </Animated.View>
-          )}
+                <SpinButton
+                  onPress={handleSpin}
+                  weeklyMode={prefs.weeklyMode}
+                  disabled={spinDisabled}
+                />
+              </Animated.View>
 
-          {/* Remaining spins for guests */}
-          {!auth.isAuthenticated && !isLimitReached && spinsRemaining < 3 && (
-            <Animated.View
-              entering={FadeInDown.delay(100).duration(400).springify()}
-              className="mt-4"
-            >
-              <Text className="font-body text-xs text-txt-soft text-center">
-                {spinsRemaining} free spin
-                {spinsRemaining !== 1 ? "s" : ""} remaining today
-              </Text>
-            </Animated.View>
-          )}
+              {/* Guest limit upsell banner */}
+              {isLimitReached && !auth.isAuthenticated && (
+                <Animated.View
+                  entering={FadeInDown.delay(100).duration(400).springify()}
+                  className="mt-6 items-center"
+                >
+                  <Text className="font-body text-sm text-txt-soft text-center mb-3">
+                    You've used your 3 free spins for today.
+                  </Text>
+                  <Pressable
+                    onPress={() => {
+                      setSnapshot("/");
+                      router.push("/(modal)/account");
+                    }}
+                    className="px-6 py-2.5 rounded-btn bg-warm"
+                    accessibilityRole="button"
+                    accessibilityLabel="Sign up for unlimited spins"
+                  >
+                    <Text className="font-body-medium text-sm text-white">
+                      Sign up for unlimited spins
+                    </Text>
+                  </Pressable>
+                </Animated.View>
+              )}
 
-          {/* Pool loading indicator */}
-          {pool.isLoading && (
-            <Animated.View
-              entering={FadeInDown.delay(100).duration(400).springify()}
-              className="mt-4"
-            >
-              <Text className="font-body text-xs text-txt-soft text-center">
-                Loading recipes…
-              </Text>
-            </Animated.View>
+              {/* Remaining spins for guests */}
+              {!auth.isAuthenticated && !isLimitReached && spinsRemaining < 3 && (
+                <Animated.View
+                  entering={FadeInDown.delay(100).duration(400).springify()}
+                  className="mt-4"
+                >
+                  <Text className="font-body text-xs text-txt-soft text-center">
+                    {spinsRemaining} free spin
+                    {spinsRemaining !== 1 ? "s" : ""} remaining today
+                  </Text>
+                </Animated.View>
+              )}
+
+              {/* Pool loading indicator */}
+              {pool.isLoading && (
+                <Animated.View
+                  entering={FadeInDown.delay(100).duration(400).springify()}
+                  className="mt-4"
+                >
+                  <Text className="font-body text-xs text-txt-soft text-center">
+                    Loading recipes…
+                  </Text>
+                </Animated.View>
+              )}
+            </>
           )}
         </View>
 
@@ -309,7 +368,6 @@ export default function HomeScreen() {
               gap: 2,
             }}
           >
-            {/* Me tab */}
             <Pressable
               onPress={() => {
                 haptic.light();
@@ -324,13 +382,11 @@ export default function HomeScreen() {
               <Text className="font-body-medium text-[11px] text-txt-soft">me</Text>
             </Pressable>
 
-            {/* Spin tab — always active on this screen */}
             <View style={{ alignItems: "center", paddingHorizontal: 20, paddingVertical: 6, gap: 3 }}>
               <Ionicons name="shuffle-outline" size={18} color={Colors.warm} />
               <Text className="font-body-medium text-[11px] text-warm">spin</Text>
             </View>
 
-            {/* Saved tab */}
             <Pressable
               onPress={() => { haptic.light(); router.push("/saved"); }}
               style={{ alignItems: "center", paddingHorizontal: 20, paddingVertical: 6, gap: 3 }}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { View, Text, Pressable } from "react-native";
 import { useRouter } from "expo-router";
 import { Image } from "expo-image";
@@ -42,7 +42,7 @@ export default function HomeScreen() {
   const { state: prefs, setWeeklyMode } = usePreferences();
   const { state: auth } = useAuth();
   const { data: userProfile } = useUserProfile();
-  const { state: ui, setSpinning, showToast } = useUI();
+  const { setSpinning, showToast } = useUI();
   const { setSnapshot } = useAuthRedirect();
   const spinRecipe = useSpinRecipe();
   const spinWeeklyPlan = useSpinWeeklyPlan();
@@ -65,12 +65,12 @@ export default function HomeScreen() {
     if (pool.isSuccess) console.log('[index.tsx] pool loaded —', pool.data?.length, 'recipes');
   }
 
-  const request = {
+  const request = useMemo(() => ({
     dietary: Array.from(prefs.dietary),
     time: prefs.time,
     calories: prefs.calories,
     isPro: userProfile?.isPro ?? false,
-  };
+  }), [prefs.dietary, prefs.time, prefs.calories, userProfile?.isPro]);
 
   const handleSpin = useCallback(() => {
     if (__DEV__) {
@@ -114,7 +114,7 @@ export default function HomeScreen() {
         },
       });
     }
-  }, [prefs, request, pool.isLoading, pool.isError, pool.data, spinRecipe, spinWeeklyPlan, setSpinning, auth.isAuthenticated, incrementSpinCount]);
+  }, [prefs, request, pool.isLoading, pool.isError, pool.data, spinRecipe, spinWeeklyPlan, setSpinning, showToast, auth.isAuthenticated, incrementSpinCount]);
 
   // Wheel animation finished — stop spinning, show the result card
   const handleSpinComplete = useCallback(() => {
@@ -160,7 +160,7 @@ export default function HomeScreen() {
     } else {
       saveRecipe.mutate({ recipeId: spinResult.data.id, recipe: spinResult.data });
     }
-  }, [spinResult, isRecipeSaved, auth.isAuthenticated, savedRecipes, saveRecipe, unsaveRecipe, setSnapshot, router]);
+  }, [spinResult, isRecipeSaved, auth.isAuthenticated, saveRecipe, unsaveRecipe, setSnapshot, router]);
 
   // Active filters drive the hamburger indicator + context line
   const hasActiveFilters =

--- a/components/CLAUDE.md
+++ b/components/CLAUDE.md
@@ -71,7 +71,8 @@ interface Props {
 | `SmartGroceryCard` | Weekly plan shared ingredients callout | `ingredients` |
 | `SocialButton` | Social auth button | `provider: "google" \| "facebook" \| "apple"`, `onPress` |
 | `SpinButton` | Hero spin button with 3D press, pulse rings, depth base | `onPress`, `weeklyMode`, `disabled?` |
-| `SpinningOverlay` | Full-screen spin animation overlay | `visible` |
+| `SpinningOverlay` | Inline spinning wheel (replaces SpinButton in-place during spin) | `onComplete` |
+| `SpinResultCard` | Compact result card (recipe or weekly plan variant) | `result`, `onViewFullRecipe`, `onSpinAgain`, `saved?`, `onToggleSave?` |
 | `TagChip` | Recipe tag label chip | `label` |
 | `Toast` | Auto-dismissing toast | `message`, `variant: "default" \| "error"` |
 | `Toggle` | Toggle switch (explicit style layout, 44x24px track) | `variant: "warm" \| "green"`, `value`, `onToggle` |
@@ -126,12 +127,14 @@ import Animated, { FadeInDown, FadeOut } from "react-native-reanimated";
 // Uses withRepeat(-1, false) — no reverse, smooth restart via 0-duration reset.
 ```
 
-### Spin Animation
+### Inline Spin Wheel (InlineSpinWheel)
 ```tsx
-rotation.value = withTiming(1080, {
-  duration: 700,
-  easing: Easing.bezier(0.4, 0, 0.2, 1),
-});
+// Single smooth rotation — 2160deg (6 turns) over 4s, linear easing.
+// No withRepeat — one continuous withTiming avoids frame-drop snap-backs.
+rotation.value = withTiming(2160, { duration: 4000, easing: Easing.linear });
+
+// At 2000ms: haptic.success(), bounce up (-20px) then slide down (40px) + fade out.
+// At 2400ms: onComplete() fires → parent swaps to SpinResultCard.
 ```
 
 ### Float-away (confFloat — ConfettiEmoji)
@@ -146,7 +149,8 @@ opacity.value = withDelay(delay, withTiming(0, { duration: 1500 }));
 - **3dPress** — SpinButton press: translateY 0→5px, shadow collapses (80ms in, 200ms out)
 - **gentleUp** — Content entrance: `FadeInDown` with staggered delays
 - **slideUp** — Result cards: `SlideInDown`
-- **spinWheel** — Spin sequence: rotation 0→1080deg cubic-bezier
+- **inlineWheel** — InlineSpinWheel: continuous 2160deg/4s linear rotation, bounce+fade exit at 2s
+- **resultCardEntry** — SpinResultCard: `FadeInDown.duration(400).springify()`
 - **confFloat** — Celebration: translateY/scale/opacity float-away
 - **loadingDots** — Button loading: 3 dots staggered `translateY` bounce
 

--- a/components/SpinResultCard.tsx
+++ b/components/SpinResultCard.tsx
@@ -1,0 +1,189 @@
+import React from "react";
+import { View, Text } from "react-native";
+import Animated, { FadeInDown } from "react-native-reanimated";
+import { Ionicons } from "@expo/vector-icons";
+import { HeartButton } from "@/components/HeartButton";
+import { MetaPill } from "@/components/MetaPill";
+import { PrimaryButton } from "@/components/PrimaryButton";
+import { SecondaryButton } from "@/components/SecondaryButton";
+import { Colors } from "@/constants/colors";
+import type { Recipe, WeeklyPlan } from "@/types";
+
+type SpinResultData =
+  | { type: "recipe"; data: Recipe }
+  | { type: "plan"; data: WeeklyPlan };
+
+interface SpinResultCardProps {
+  result: SpinResultData;
+  saved?: boolean;
+  onToggleSave?: () => void;
+  onViewFullRecipe: () => void;
+  onSpinAgain: () => void;
+}
+
+/**
+ * Compact summary card shown inline on the home screen after a spin.
+ *
+ * Two variants:
+ *  - recipe: emoji, title + heart, divider, meta pills, view/spin buttons
+ *  - plan: calendar icon + heading, 3 day previews, view/spin buttons
+ *
+ * Entrance: FadeInDown.duration(400).springify()
+ */
+export function SpinResultCard({
+  result,
+  saved = false,
+  onToggleSave,
+  onViewFullRecipe,
+  onSpinAgain,
+}: SpinResultCardProps) {
+  if (result.type === "recipe") {
+    return <RecipeVariant recipe={result.data} saved={saved} onToggleSave={onToggleSave} onViewFullRecipe={onViewFullRecipe} onSpinAgain={onSpinAgain} />;
+  }
+  return <PlanVariant plan={result.data} onViewFullRecipe={onViewFullRecipe} onSpinAgain={onSpinAgain} />;
+}
+
+function RecipeVariant({
+  recipe,
+  saved,
+  onToggleSave,
+  onViewFullRecipe,
+  onSpinAgain,
+}: {
+  recipe: Recipe;
+  saved: boolean;
+  onToggleSave?: () => void;
+  onViewFullRecipe: () => void;
+  onSpinAgain: () => void;
+}) {
+  const pills: string[] = [];
+  if (recipe.time) pills.push(recipe.time);
+  if (recipe.calories && recipe.calories !== "—") pills.push(recipe.calories);
+  if (recipe.servings) pills.push(recipe.servings);
+
+  return (
+    <Animated.View
+      entering={FadeInDown.duration(400).springify()}
+      className="bg-card rounded-card p-lg"
+      style={{
+        width: "100%",
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.08,
+        shadowRadius: 12,
+        elevation: 4,
+      }}
+    >
+      {/* Emoji + title + heart */}
+      <View className="flex-row items-center gap-md">
+        <Text style={{ fontSize: 32 }}>{recipe.emoji}</Text>
+        <View className="flex-1">
+          <Text className="font-display text-[18px] text-txt" numberOfLines={2}>
+            {recipe.name}
+          </Text>
+        </View>
+        {onToggleSave && (
+          <HeartButton filled={saved} onPress={onToggleSave} />
+        )}
+      </View>
+
+      {/* Divider */}
+      <View className="h-px bg-border my-md" />
+
+      {/* Meta pills */}
+      {pills.length > 0 && (
+        <View className="flex-row flex-wrap gap-sm mb-lg">
+          {pills.map((pill) => (
+            <MetaPill key={pill} label={pill} />
+          ))}
+        </View>
+      )}
+
+      {/* Buttons */}
+      <View className="gap-sm">
+        <PrimaryButton
+          label="View full recipe"
+          onPress={onViewFullRecipe}
+          accessibilityLabel="View full recipe details"
+        />
+        <SecondaryButton
+          label="Spin again"
+          onPress={onSpinAgain}
+          variant="ghost"
+          accessibilityLabel="Spin for another recipe"
+        />
+      </View>
+    </Animated.View>
+  );
+}
+
+function PlanVariant({
+  plan,
+  onViewFullRecipe,
+  onSpinAgain,
+}: {
+  plan: WeeklyPlan;
+  onViewFullRecipe: () => void;
+  onSpinAgain: () => void;
+}) {
+  const previewDays = plan.days.slice(0, 3);
+  const remaining = plan.days.length - 3;
+
+  return (
+    <Animated.View
+      entering={FadeInDown.duration(400).springify()}
+      className="bg-card rounded-card p-lg"
+      style={{
+        width: "100%",
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.08,
+        shadowRadius: 12,
+        elevation: 4,
+      }}
+    >
+      {/* Header */}
+      <View className="flex-row items-center gap-md mb-md">
+        <Ionicons name="calendar-outline" size={24} color={Colors.warm} />
+        <Text className="font-display text-[18px] text-txt">
+          Your 7-day plan is ready
+        </Text>
+      </View>
+
+      {/* Day previews */}
+      <View className="gap-sm mb-lg">
+        {previewDays.map((dayEntry) => (
+          <View key={dayEntry.day} className="flex-row items-center gap-sm">
+            <Text className="font-body-semibold text-[11px] text-txt-soft w-[32px]">
+              {dayEntry.day.slice(0, 3)}
+            </Text>
+            <Text style={{ fontSize: 16 }}>{dayEntry.recipe.emoji}</Text>
+            <Text className="font-body text-[13px] text-txt flex-1" numberOfLines={1}>
+              {dayEntry.recipe.name}
+            </Text>
+          </View>
+        ))}
+        {remaining > 0 && (
+          <Text className="font-body text-[11px] text-txt-soft ml-[32px]">
+            +{remaining} more
+          </Text>
+        )}
+      </View>
+
+      {/* Buttons */}
+      <View className="gap-sm">
+        <PrimaryButton
+          label="View full plan"
+          onPress={onViewFullRecipe}
+          accessibilityLabel="View full weekly plan"
+        />
+        <SecondaryButton
+          label="Spin again"
+          onPress={onSpinAgain}
+          variant="ghost"
+          accessibilityLabel="Spin for another plan"
+        />
+      </View>
+    </Animated.View>
+  );
+}

--- a/components/SpinningOverlay.tsx
+++ b/components/SpinningOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { View, Text } from "react-native";
 import Animated, {
   useSharedValue,
@@ -7,83 +7,184 @@ import Animated, {
   withSequence,
   Easing,
   FadeIn,
-  FadeOut,
 } from "react-native-reanimated";
-import { Colors } from "@/constants/colors";
 import { haptic } from "@/lib/haptics";
 
-interface SpinningOverlayProps {
+interface InlineSpinWheelProps {
   onComplete: () => void;
 }
 
+// Quadrant colors — single-use, not design tokens
+const COLORS = {
+  terracotta: "#C65D3D",
+  golden: "#E8A838",
+  sage: "#7BA688",
+  blush: "#E8A8A0",
+};
+
+const WHEEL_SIZE = 200;
+const HALF = WHEEL_SIZE / 2;
+const HUB_SIZE = 56;
+// Match SpinButton's PRESS_DEPTH so the wheel sits at the same vertical center
+const PRESS_DEPTH = 5;
+
 /**
- * Full-screen spinning overlay shown during recipe spin.
+ * Inline spinning wheel — replaces SpinButton in-place while spinning.
  *
- * Phases:
- *  1. "spin" — conic gradient wheel spins 1080deg (0.7s)
- *  2. "black" — dark screen with "choosing..." text
- *  3. Calls onComplete -> success haptic
+ * Same 200px diameter as SpinButton, with matching outer container height
+ * (WHEEL_SIZE + PRESS_DEPTH) so it occupies the exact same space.
  *
- * Design spec (spinWheel):
- *  - 0.7s cubic-bezier(0.4, 0, 0.2, 1)
- *  - 0 -> 1080deg rotation
+ * Rotation uses a single long withTiming (3600deg over 10s, linear) for
+ * perfectly smooth continuous spin with no frame drops or reset jumps.
+ *
+ * Timeline:
+ *  0ms      — Wheel fades in, smooth continuous rotation starts
+ *  2000ms   — haptic.success(), bounce up 20px then slide down 40px + fade
+ *  2400ms   — onComplete() fires (parent swaps to result card)
  */
-export function SpinningOverlay({ onComplete }: SpinningOverlayProps) {
-  const [phase, setPhase] = useState<"spin" | "black">("spin");
+export function InlineSpinWheel({ onComplete }: InlineSpinWheelProps) {
   const rotation = useSharedValue(0);
+  const translateY = useSharedValue(0);
+  const opacity = useSharedValue(1);
 
   useEffect(() => {
-    // Spin phase
-    rotation.value = withTiming(1080, {
-      duration: 700,
-      easing: Easing.bezier(0.4, 0, 0.2, 1),
+    // Single smooth rotation — 2160deg (6 full turns) over 4s
+    // The animation will be interrupted by the exit at ~2s, but there's no
+    // snap/reset because it's one continuous timing curve.
+    rotation.value = withTiming(2160, {
+      duration: 4000,
+      easing: Easing.linear,
     });
 
-    const t1 = setTimeout(() => setPhase("black"), 700);
-    const t2 = setTimeout(() => {
+    // At 2000ms: haptic + bounce up then slide down + fade
+    const hapticTimer = setTimeout(() => {
       haptic.success();
+      translateY.value = withSequence(
+        withTiming(-20, { duration: 150, easing: Easing.out(Easing.ease) }),
+        withTiming(40, { duration: 250, easing: Easing.in(Easing.ease) })
+      );
+      opacity.value = withSequence(
+        withTiming(1, { duration: 150 }),
+        withTiming(0, { duration: 250 })
+      );
+    }, 2000);
+
+    // At 2400ms: fire onComplete (after bounce animation finishes)
+    const completeTimer = setTimeout(() => {
       onComplete();
-    }, 1100);
+    }, 2400);
 
     return () => {
-      clearTimeout(t1);
-      clearTimeout(t2);
+      clearTimeout(hapticTimer);
+      clearTimeout(completeTimer);
     };
-  }, [onComplete, rotation]);
+  }, [onComplete, rotation, translateY, opacity]);
 
-  const spinStyle = useAnimatedStyle(() => ({
-    transform: [{ rotate: `${rotation.value}deg` }],
+  const wheelStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateY: translateY.value },
+      { rotate: `${rotation.value}deg` },
+    ],
+    opacity: opacity.value,
   }));
 
-  if (phase === "black") {
-    return (
-      <Animated.View
-        entering={FadeIn.duration(200)}
-        className="flex-1 items-center justify-center bg-[#1a1714]"
-      >
-        <Text className="font-display-italic text-base text-warm-light opacity-60 italic">
-          choosing...
-        </Text>
-      </Animated.View>
-    );
-  }
+  const textStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateY: translateY.value }],
+  }));
 
   return (
-    <View className="flex-1 items-center justify-center bg-bg">
-      <Animated.View
-        style={[
-          spinStyle,
-          {
-            width: 160,
-            height: 160,
-            borderRadius: 80,
-            backgroundColor: Colors.warm,
-          },
-        ]}
-        className="items-center justify-center"
-      >
-        <View className="w-[50px] h-[50px] rounded-full bg-bg" />
+    <Animated.View
+      entering={FadeIn.duration(200)}
+      style={{ alignItems: "center" }}
+      accessibilityLabel="Spinning for a recipe"
+    >
+      {/* Match SpinButton's outer container: WHEEL_SIZE + PRESS_DEPTH tall */}
+      <View style={{ width: WHEEL_SIZE, height: WHEEL_SIZE + PRESS_DEPTH, justifyContent: "center" }}>
+        <Animated.View style={[wheelStyle, { alignSelf: "center" }]}>
+          <View
+            style={{
+              width: WHEEL_SIZE,
+              height: WHEEL_SIZE,
+              borderRadius: HALF,
+              overflow: "hidden",
+            }}
+          >
+            {/* Top-left: Terracotta */}
+            <View
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: HALF,
+                height: HALF,
+                backgroundColor: COLORS.terracotta,
+              }}
+            />
+            {/* Top-right: Golden */}
+            <View
+              style={{
+                position: "absolute",
+                top: 0,
+                right: 0,
+                width: HALF,
+                height: HALF,
+                backgroundColor: COLORS.golden,
+              }}
+            />
+            {/* Bottom-right: Sage */}
+            <View
+              style={{
+                position: "absolute",
+                bottom: 0,
+                right: 0,
+                width: HALF,
+                height: HALF,
+                backgroundColor: COLORS.sage,
+              }}
+            />
+            {/* Bottom-left: Blush */}
+            <View
+              style={{
+                position: "absolute",
+                bottom: 0,
+                left: 0,
+                width: HALF,
+                height: HALF,
+                backgroundColor: COLORS.blush,
+              }}
+            />
+
+            {/* Center hub — matches app bg so it looks hollow */}
+            <View
+              style={{
+                position: "absolute",
+                top: (WHEEL_SIZE - HUB_SIZE) / 2,
+                left: (WHEEL_SIZE - HUB_SIZE) / 2,
+                width: HUB_SIZE,
+                height: HUB_SIZE,
+                borderRadius: HUB_SIZE / 2,
+                backgroundColor: "#FAF6F1",
+                zIndex: 10,
+              }}
+            />
+          </View>
+        </Animated.View>
+      </View>
+
+      {/* Status text — mt-8 (32px) matches SpinButton's "tap to spin" text */}
+      <Animated.View style={[{ marginTop: 32 }, textStyle]}>
+        <Text
+          style={{
+            fontFamily: "Fraunces_700Bold_Italic",
+            fontSize: 14,
+            color: COLORS.blush,
+            letterSpacing: 0.5,
+          }}
+        >
+          finding your meal...
+        </Text>
       </Animated.View>
-    </View>
+    </Animated.View>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced the broken full-screen spin overlay with an **inline spinning wheel** (`InlineSpinWheel`) that replaces the SpinButton in-place during the spin animation
- Added **`SpinResultCard`** — a compact result card (recipe or weekly plan variant) that appears on the home screen after spinning, with View/Spin Again actions
- Refactored the home screen center area into 3 inline states (idle → spinning → result) — no more navigation-based transitions during the spin flow
- Context line (active filter summary) now stays visible during spinning to prevent layout shift

## Changes
| File | What changed |
|---|---|
| `components/SpinningOverlay.tsx` | Complete rewrite → `InlineSpinWheel` with 4-color quadrant wheel, continuous 2160deg/4s linear rotation, bounce+fade exit, haptic at 2s |
| `components/SpinResultCard.tsx` | **New** — recipe variant (emoji, title, HeartButton, MetaPills, View/Spin Again) and weekly plan variant (3-day preview, +N more) |
| `app/index.tsx` | 3-state center area, inline `spinResult` state, saved recipes integration, context line persists during spin |
| `__tests__/SpinningOverlay.test.tsx` | **New** — 3 tests (render, haptic timing, onComplete timing) |
| `__tests__/SpinResultCard.test.tsx` | **New** — 12 tests (both variants, buttons, HeartButton, meta pills) |
| `__tests__/HomeScreen.test.tsx` | Added useSavedRecipes mock |
| `CLAUDE.md`, `app/CLAUDE.md`, `components/CLAUDE.md`, `__tests__/CLAUDE.md` | Updated docs for new components, animation patterns, test coverage |

## Test plan
- [x] `npx tsc --noEmit` — no TypeScript errors
- [x] `npm test` — all 224 tests pass (18 suites)
- [x] Manual: tap spin → wheel replaces button in-place → wheel spins smoothly → bounce+fade exit → result card appears
- [x] Manual: "View full recipe" navigates to /result, "Spin again" resets to idle
- [x] Manual: context line stays in place during spinning (no layout jump)
- [x] Manual: weekly mode → spin → plan card with day previews

🤖 Generated with [Claude Code](https://claude.com/claude-code)